### PR TITLE
DAT-1122 django2 compatibility

### DIFF
--- a/django_model_changes/changes.py
+++ b/django_model_changes/changes.py
@@ -116,7 +116,7 @@ class ChangesMixin(object):
 
             # Foreign fields require special care because we don't want to trigger a database query when the field is
             # not yet cached.
-            if field.rel:
+            if field.remote_field:
                 descriptor = self.__class__.__dict__[field.name]
                 if hasattr(self, descriptor.cache_name):
                     fields[field.name] = getattr(self, descriptor.cache_name, None)

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ os.chdir(os.path.normpath(os.path.join(os.path.abspath(__file__), os.pardir)))
 
 setup(
     name='django-model-changes-py3',
-    version='0.15.1',
+    version='0.15.2',
     packages=find_packages(exclude=['tests']),
     license='MIT License',
     description='django-model-changes allows you to track model instance changes.',


### PR DESCRIPTION
### Description

This PR makes this package compatible with django2.

Monolith Test pass in the monolith testing PR (read there for more notes): https://github.com/paymentworks/monolith/pull/4271


#### Jira Tracking

https://paymentworks.atlassian.net/browse/DAT-1122

#### Screenshots (If Applicable)
N/A

#### Describe Rollback Scenarios
Revert

#### What are some risks involved if the code in this PR is released?
This package is the cornerstone of updates / edit registrations.

#### Scenarios Manually Tested on Load Environments
✅ Create an Update
✅ Tests pass on monolith (django1)

#### Migration Notes/Highlights
N/A