### PR TITLE
DAT-1443 handle cache_name deprecation in django>=2.0

### DIFF
--- a/django_model_changes/changes.py
+++ b/django_model_changes/changes.py
@@ -118,8 +118,9 @@ class ChangesMixin(object):
             # Foreign fields require special care because we don't want to trigger a database query when the field is
             # not yet cached.
             # TODO remove is_django_version_2_or_higher() after monolith is upgraded
-            if is_django_version_2_or_higher() and field.is_relation and field.is_cached(self):
-                fields[field.name] = field.get_cached_value(self)
+            if is_django_version_2_or_higher():
+                if field.is_relation and field.is_cached(self):
+                    fields[field.name] = field.get_cached_value(self)
             elif field.remote_field:
                 descriptor = self.__class__.__dict__[field.name]
                 if hasattr(self, descriptor.cache_name):

--- a/django_model_changes/changes.py
+++ b/django_model_changes/changes.py
@@ -121,10 +121,11 @@ class ChangesMixin(object):
             if is_django_version_2_or_higher():
                 if field.is_relation and field.is_cached(self):
                     fields[field.name] = field.get_cached_value(self)
-            elif field.remote_field:
-                descriptor = self.__class__.__dict__[field.name]
-                if hasattr(self, descriptor.cache_name):
-                    fields[field.name] = getattr(self, descriptor.cache_name, None)
+            else:
+                if field.remote_field:
+                    descriptor = self.__class__.__dict__[field.name]
+                    if hasattr(self, descriptor.cache_name):
+                        fields[field.name] = getattr(self, descriptor.cache_name, None)
 
         return fields
 

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ os.chdir(os.path.normpath(os.path.join(os.path.abspath(__file__), os.pardir)))
 
 setup(
     name='django-model-changes-py3',
-    version='0.15.2',
+    version='0.15.3',
     packages=find_packages(exclude=['tests']),
     license='MIT License',
     description='django-model-changes allows you to track model instance changes.',


### PR DESCRIPTION
See notes on testing here:
https://github.com/paymentworks/monolith/pull/4767


#### Jira Tracking

https://paymentworks.atlassian.net/browse/DAT-1443


#### Describe Rollback Scenarios
Revert





Copying the notes from the linked monolith PR in case it is inaccessible after closing it:

> This PR points to the django-model-changes here: https://github.com/paymentworks/django-model-changes-py3/pull/3 in order to test the changes made there.
> 
> The checks below for this PR show that testing passes for our current Django version.
> 
> I tested running this in https://github.com/paymentworks/monolith/pull/4766 with Django 2.0. Since other upgrades are needed, not all tests passed, but I didn't see any tests fail due to the model changes package.
> 
> _Note_, I also made a tiny change in order to run tests with django 2 by adding: `fields=`
> 
> **Don't actually merge this PR, we just need to merge the linked django-model-changes PR*.*