### PR TITLE
Fix DAT-2307: Eliminate infinite recursion when deferred fields are present

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ os.chdir(os.path.normpath(os.path.join(os.path.abspath(__file__), os.pardir)))
 
 setup(
     name='django-model-changes-py3',
-    version='0.15.4',
+    version='0.15.5',
     packages=find_packages(exclude=['tests']),
     license='MIT License',
     description='django-model-changes allows you to track model instance changes.',

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -188,3 +188,9 @@ class ChangesMixinBeforeAndCurrentTestCase(TestCase):
         self.assertDictContainsSubset({'id': article.pk, 'user_id': me.pk}, article.old_state())
         self.assertDictContainsSubset({'id': article.pk, 'user_id': you.pk}, article.previous_state())
         self.assertDictContainsSubset({'id': article.pk, 'user_id': you.pk}, article.current_state())
+
+
+    def test_deffered_fields_no_infinite_recursion(self):
+        user = User()
+        user.save()
+        User.objects.only('id').get(id=user.id)


### PR DESCRIPTION
When querying a django model you can use `.only(<field_name>)` or `.defer(<field_name>)` to constrain the fields pulled from the db to just the fields requested. Not all of the fields on the model. When/if those fields are accessed in the future then django will make another trip to the database to request the field. This is an optimization that allows one to only get the fields they need for specific use cases.

In our previous implementation we were using `getattr`. In the case of deferred fields if the field was deferred getattr would make a request out to the database to get the field. Even in the case of field.attname. This would result in infinite recursion where we would try to initialize and object using deferred fields, then call getattr on those deferred fields, and then recurse trying to initialize again.

Changing to use only the attributes already available on `__dict__` makes sure we don't go out to the database and end up in infinite recursion. In the case of deferred fields the field is not on `__dict__` so we just won't include it in fields.

In DAT-2307 this issue cropped up because django 3 optimized the model delete code to use a `.only()` (deferred field) under certain circumstances. This meant that at times deletes would result in infinite recursion.