### PR TITLE
Add Python 3.8 to CI and Remove Django v2

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,20 +7,18 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        versions: [
-          {python: '3.7', django: '2.2.28'},
-          {python: '3.7', django: '3.2.25'},
-        ]
+        python: ["3.7.16", "3.8.20"]
+        django: ["3.2.25"]
     steps:
       - name: Checkout source code
-        uses: actions/checkout@v4
-      - name: Set up Python ${{ matrix.versions.python }}
-        uses: actions/setup-python@v4
+        uses: actions/checkout@v5
+      - name: Set up Python ${{ matrix.python }}
+        uses: actions/setup-python@v5
         with:
-          python-version: ${{ matrix.versions.python }}
+          python-version: ${{ matrix.python }}
       - name: Install Dependencies
         run: |
           pip install -e .
-          pip install django==${{ matrix.versions.django }}
+          pip install django==${{ matrix.django }}
       - name: Run tests
         run: python runtests.py

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        python: ["3.7.16", "3.8.20"]
+        python: ["3.7.16", "3.8.18"]
         django: ["3.2.25"]
     steps:
       - name: Checkout source code


### PR DESCRIPTION
## Description

We're no longer using Django v2 anymore, so we can get rid of it from the test matrix. Furthermore, we're looking to migrate to Python 3.8, so we want to ensure the tests pass for django-model-changes on 3.8.

## Jira Tracking

https://paymentworks.atlassian.net/browse/NOVA-173